### PR TITLE
#63 Add singular aliases for `groups` and `repos` commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `git fetch` command
 - `git pull` command
+- Singular aliases for `groups` and `repos` commands
 
 ### Fixed
 

--- a/cmd/groups.go
+++ b/cmd/groups.go
@@ -7,8 +7,9 @@ import (
 
 func CreateGroupsCommand() *cobra.Command {
 	var result = &cobra.Command{
-		Use:   "groups",
-		Short: "Manages repositories groups",
+		Use:     "groups",
+		Short:   "Manages repositories groups",
+		Aliases: []string{"group"},
 	}
 
 	result.AddCommand(groups.CreateListCommand())

--- a/cmd/repos.go
+++ b/cmd/repos.go
@@ -7,8 +7,9 @@ import (
 
 func CreateReposCommand() *cobra.Command {
 	var result = &cobra.Command{
-		Use:   "repos",
-		Short: "Configures repositories that bulker works with",
+		Use:     "repos",
+		Short:   "Configures repositories that bulker works with",
+		Aliases: []string{"repo"},
 	}
 
 	result.AddCommand(repos.CreateListCommand())


### PR DESCRIPTION
Closes #63 