### PR TITLE
#78 Print empty array instead of `null` in `json` output mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Empty array to be printed in `--output json` mode when no repositories matched
+
 ## [0.7.0] - 2022-08-05
 
 ### Added

--- a/internal/output/json_writer.go
+++ b/internal/output/json_writer.go
@@ -12,7 +12,9 @@ type JsonWriter struct {
 }
 
 func (w JsonWriter) WriteMessage(value map[string]EntityInfo) string {
-	var valueToLog []interface{}
+	// An empty slice is created in order to have an empty json when the slice is marshalled without any values
+	//goland:noinspection GoPreferNilSlice
+	valueToLog := []any{}
 
 	keys := maps.Keys(value)
 	slices.Sort(keys)


### PR DESCRIPTION
When no repository matched

Closes #78 